### PR TITLE
Exposed input validation against internal regular expression

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -122,10 +122,21 @@ Using a custom seed:
 ```javascript
 var srand = require('srand'); //https://github.com/isaacs/node-srand (npm install srand)
 srand.seed(1000);
-    
+
 roll.random = function(){ return srand.random(); };
-    
+
 console.log(roll.roll('2d6+5').result);
+```
+
+Validating user input:
+
+```javascript
+userInput = "garbage"
+valid = roll.validate(userInput);
+
+if (!valid) {
+  console.error(userInput + " is not valid!");
+}
 ```
 
 ## Credits

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ var transformationFunctions = {
       sum += rolledDice[i];
     return sum;
   },
-  
+
   'bestOf': function(rolledDice, value){
     var sorted = rolledDice.sort(function(a,b){
       return b - a;
@@ -48,7 +48,7 @@ var transformationFunctions = {
       result.push(sorted[i]);
     return result;
   },
-  
+
   'worstOf': function(rolledDice, value){
     var sorted = rolledDice.sort(function(a,b){
       return a - b;
@@ -58,30 +58,39 @@ var transformationFunctions = {
       result.push(sorted[i]);
     return result;
   },
-  
+
   'add': function(number, value){
     return number + (value / 1);
   },
-  
+
   'subtract': function(number, value){
     return number - value;
   },
-  
+
   'multiply': function(number, value){
     return number * value;
   },
-  
+
   'divide': function(number, value){
     return number / value;
   }
 };
 
+var regex = /^(\d*)d(\d+|\%)(([\+\-\/\*b])(\d+))?$/;
+
 var roll = module.exports = {
-  
+
   random: function(){ return Math.random(); },
-  
+
+  validate: function(s){
+    return regex.test(s);
+  },
+
   parse: function(s){
-    var regex = /^(\d*)d(\d+|\%)(([\+\-\/\*b])(\d+))?$/;
+    if (!this.validate(s)){
+      throw new Error("Invalid input: " + s);
+    }
+
     var match = regex.exec(s);
     //for(var i = 0; i < match.length; i++) console.log('match#%d: %s', i, match[i]);
     return {
@@ -99,15 +108,15 @@ var roll = module.exports = {
           }
         };
   },
-  
+
   roll: function(input){
     if(typeof input === 'string')
       input = this.parse(input);
-    
+
     var rolled = [];
     for(var i = 0; i < input.quantity; i++)
       rolled.push(Math.floor((this.random() * input.sides) + 1));
-    
+
     var calculations = [];
     var result = rolled;
     for(var i = 0; i < input.transformations.length; i++){
@@ -130,7 +139,7 @@ var roll = module.exports = {
       );
     }
     calculations.unshift(result);
-    
+
     return {
       input: input,
       calculations: calculations,
@@ -138,5 +147,5 @@ var roll = module.exports = {
       result: result
     };
   }
-  
+
 };

--- a/test/works.js
+++ b/test/works.js
@@ -26,4 +26,15 @@ describe('roll', function(){
     var result = roll.roll('2d20-3');
     result.result.should.equal(15);
   });
+
+  it('validates input', function(){
+    (function(){
+      roll.roll('garbage')
+    }).should["throw"]("Invalid input: garbage");
+  });
+
+  it('exposes validation', function(){
+    roll.validate('2d20-3').should.equal(true);
+    roll.validate('garbage').should.equal(false);
+  });
 });


### PR DESCRIPTION
I added a new function to exports that tests the roll string against the matching regex. The `roll` function will also take advantage of this instead of throwing a `TypeError: Cannot read property '1' of null` when encountering input it didn't expect.
