### PR TITLE
non-breaking change to rolled array

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -82,6 +82,8 @@ Seeing what was rolled, rather than the sum:
 ```javascript
 var yahtzee = roll.roll('5d6');
 console.log(yahtzee.rolled); //yahtzee.rolled will return something like [5, 2, 4, 6, 1] rather than the sum
+var blessedSneaker = roll.roll('2d20b1+1d4+5');
+console.log(blessedSneaker.rolled); //blessedSneaker.rolled will return an array containing an array for each component that is a roll of the dice, in the order in which they occurred, e.g. [[19,3],[1]]
 ```
 
 Getting the highest two dice of the set:

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,8 @@
     regex =  /^(\d*)d(\d+|\%)(([\+\-\/\*bw])(\d+))?(([\+\-\/\*])(\d+|(\d*)d(\d+|\%)(([\+\-\/\*bw])(\d+))?))*$/,
     roll,
     cleaner,
-    sumResult = false;
+    sumResult = false,
+    filler = [];
 
   roll = function (random) {
     this.random = random || function () {
@@ -34,7 +35,8 @@
       transformationParameter,
       transforms = [],
       opIndex = 0,
-      segments = s.split(/[\+\-]/);
+      segments = s.split(/[\+\-]/),
+      outsideRoll;
 
     if (segments[0].indexOf('b') > -1) {
       transforms.push(transformationKeys[match[4]](parseInt(match[5], 10)));
@@ -45,7 +47,8 @@
       opIndex += 1;
       transformationParameter = segments[seg]; // 2d20+3 => 3
       if (transformationParameter.indexOf('d') > -1) {
-        transforms.push(transformationKeys[operator](parseInt(this.roll(transformationParameter).result, 10)));
+        outsideRoll = this.roll(transformationParameter,true);
+        transforms.push(transformationKeys[operator](parseInt(outsideRoll.result, 10)));
       } else {
         transforms.push(transformationKeys[operator](parseInt(transformationParameter, 10)));
       }
@@ -61,7 +64,7 @@
     };
   };
 
-  roll.prototype.roll = function (input) {
+  roll.prototype.roll = function (input,invokedByParse) {
     if (!input) {
       throw new InvalidInputError();
     } else if (typeof input === 'string') {
@@ -69,17 +72,17 @@
     }
 
     var rolled = [],
-     calculations = [];
+     calculations = [],
+     carryFiller = [];
 
     while (rolled.length < input.quantity) {
       rolled.push(Math.floor((this.random() * input.sides) + 1));
     }
-
+    filler.push(rolled);
     calculations = input.transformations.reduce(function (previous, transformation) {
       var transformationFunction,
         transformationAdditionalParameter,
         sumParam = false;
-
       if (typeof transformation === 'function') { // lets you pass something custom in
         transformationFunction = transformation;
       } else if (typeof transformation === 'string') { // "sum"
@@ -109,10 +112,15 @@
       calculations[0] = transformationFunctions[cleaner](calculations[0]);
     }
 
+    if (!invokedByParse){
+      carryFiller = filler;
+      filler = [];
+    }
+
     return {
       input: input,
       calculations: calculations,
-      rolled: calculations[calculations.length - 1],
+      rolled: carryFiller,
       result: calculations[0]
     };
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -113,6 +113,9 @@
     }
 
     if (!invokedByParse){
+      if (filler.length > 1){
+        filler.unshift(filler.pop());
+      }
       carryFiller = filler.length === 1 ? filler[0] : filler;
       filler = [];
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -113,7 +113,7 @@
     }
 
     if (!invokedByParse){
-      carryFiller = filler;
+      carryFiller = filler.length === 1 ? filler[0] : filler;
       filler = [];
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -48,7 +48,7 @@
     it('d20', function () {
       var result = roll.roll('d20');
       result.rolled.length.should.equal(1);
-      result.rolled[0][0].should.equal(5);
+      result.rolled[0].should.equal(5);
       result.result.should.equal(5);
     });
 
@@ -61,9 +61,9 @@
 
     it('2d20', function () {
       var result = roll.roll('2d20');
-      result.rolled[0].length.should.equal(2);
-      result.rolled[0][0].should.equal(5);
-      result.rolled[0][1].should.equal(13);
+      result.rolled.length.should.equal(2);
+      result.rolled[0].should.equal(5);
+      result.rolled[1].should.equal(13);
       result.result.should.equal(18);
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,10 @@
         result.result.should.equal(18);
       });
 
+      it('2d20b1+1d4', function () {
+        var result = roll.roll('2d20b1+1d4');
+        result.rolled.should.deepEqual([[13,11],[1]]);
+      });
     });
 
     it('d20', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -55,7 +55,7 @@
     it('d%', function () {
       var result = roll.roll('d%');
       result.rolled.length.should.equal(1);
-      result.rolled[0][0].should.equal(25);
+      result.rolled[0].should.equal(25);
       result.result.should.equal(25);
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -45,7 +45,7 @@
 
       it('2d20b1+1d4', function () {
         var result = roll.roll('2d20b1+1d4');
-        result.rolled.should.deepEqual([[13,11],[1]]);
+        result.rolled.should.eql([[13,11],[1]]);
       });
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@
 
   var exec = require('child_process').exec,
     should = require('should'),
+    fs = require('fs'),
     Roll = require('../lib'),
     FakeRandom = require('./fake-random'),
     random = new FakeRandom([ // can only test this library if we make things not actually random
@@ -47,22 +48,22 @@
     it('d20', function () {
       var result = roll.roll('d20');
       result.rolled.length.should.equal(1);
-      result.rolled[0].should.equal(5);
+      result.rolled[0][0].should.equal(5);
       result.result.should.equal(5);
     });
 
     it('d%', function () {
       var result = roll.roll('d%');
       result.rolled.length.should.equal(1);
-      result.rolled[0].should.equal(25);
+      result.rolled[0][0].should.equal(25);
       result.result.should.equal(25);
     });
 
     it('2d20', function () {
       var result = roll.roll('2d20');
-      result.rolled.length.should.equal(2);
-      result.rolled[0].should.equal(5);
-      result.rolled[1].should.equal(13);
+      result.rolled[0].length.should.equal(2);
+      result.rolled[0][0].should.equal(5);
+      result.rolled[0][1].should.equal(13);
       result.result.should.equal(18);
     });
 
@@ -131,7 +132,7 @@
     });
 
     it('bin/roll garbage', function (done) {
-      exec(__dirname + '/../bin/roll garbage', function (err, stdout, stderr) {
+      exec((process.platform === 'win32' ? 'node ././bin/roll' : __dirname + '/../bin/roll') + ' garbage', function (err, stdout, stderr) {
         if (err) {
           should.exist(err);
           stderr.should.eql('"garbage" is not a valid input string for node-roll.\n');
@@ -142,7 +143,7 @@
     });
 
     it('bin/roll 2d20', function (done) {
-      exec(__dirname + '/../bin/roll 2d20', function (err, stdout, stderr) {
+      exec((process.platform === 'win32' ? 'node ././bin/roll' : __dirname + '/../bin/roll') + ' 2d20', function (err, stdout, stderr) {
         if (err) {
           return done(err);
         }
@@ -153,4 +154,3 @@
 
   });
 }());
-


### PR DESCRIPTION
Hi Troy,

I promise to leave this alone henceforth, but once I started using node-roll in practice I started wishing that rolled would reflect the actual dice rolled on compound dice rolls, eg 2d20b1+d4 would return an array containing the array of the two d20 rolls and an array containing the d4 roll.

Your mileage may vary as to how useful that is, but it matches my intuition about what data we would want from rolled on compound rolls.  Unfortunately, it means current tests for the contents of rolled would need to be rewritten to be tests of rolled[0].

Also changed in the test.js file is a change to paths on the two "bin/roll" tests that is necessary for running the test set on my Windows-based system.  I tried to make that part non-breaking for your original tests but wasn't sure of  your environment to test.