### PR TITLE
Add --detail flag to cli to show individual dice values

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,6 +23,12 @@ $ roll d20
 15
 $ roll d%
 99
+$ roll -d 2d20
+Dice: 13, 8
+Total: 21
+$ roll --detail 5d%
+Dice: 45, 86, 86, 4, 72
+Total: 293
 ```
 
 ## How To Use (As Library)

--- a/bin/roll
+++ b/bin/roll
@@ -4,11 +4,18 @@
   'use strict';
 
   var Roll = require(__dirname + '/../lib/index'),
+    minimist = require('minimist'),
     roll = new Roll(),
-    input = process.argv.slice(2)[0];
+    args = minimist(process.argv.slice(2), { boolean: ['d', 'detail'] });
 
   try {
-    console.log(roll.roll(input).result);
+    var dice = roll.roll(args._[0])
+    if (args.d || args.detail) {
+      console.log('Dice:', dice.rolled.join(', '));
+      console.log('Total:', dice.result);
+    } else {
+      console.log(dice.result);
+    }
     process.exit(0);
   } catch (e) {
     console.error(e.message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "roll",
+  "version": "1.2.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
   },
   "bin": {
     "roll": "bin/roll"
+  },
+  "dependencies": {
+    "minimist": "^1.2.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -212,10 +212,19 @@
         if (err) {
           return done(err);
         }
-        /^\d+\n$/.test(stdout).should.eql(true);
+        stdout.should.match(/^\d+\n$/);
         done();
       });
     });
 
+    it('bin/roll 2d20 with details', function (done) {
+      exec((process.platform === 'win32' ? 'node ././bin/roll' : __dirname + '/../bin/roll') + ' -d 2d20', function (err, stdout, stderr) {
+        if (err) {
+          return done(err);
+        }
+        stdout.should.match(/^Dice: (\d+)(,\s*\d+)*\nTotal: \d+\n$/);
+        done();
+      });
+    });
   });
 }());


### PR DESCRIPTION
First off I want to say thanks for making this, it's super useful for more tedious dice rolls.

I was using it yesterday and I wanted to see some of the specific rolls, so here is a quick patch that allows you to use `-d` or `--detail` to show them on the command line.

It does add a dependency on the [`minimist`](https://github.com/substack/minimist) module. I noticed that there is no dependencies right now so I am not sure if you are open to adding it. On one hand I get trying to stay dependency free, but rewriting cli parsing logic seems like a bad idea. I went with `minimist` because it is a well tested and proven library with no dependencies of it's own, so I don't think adding it should cause much trouble down the line.