### PR TITLE
fix: main is no longer lib but src

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "bugs": {
     "url": "https://github.com/TroyGoode/node-roll/issues"
   },
-  "main": "./lib/index.js",
+  "main": "./src/index.js",
   "engines": {
     "node": ">=4"
   },


### PR DESCRIPTION
This will fix `Error: Cannot find module '/node_modules/roll/lib/index.js'. Please verify that the package.json has a valid "main" entry`.